### PR TITLE
[NV-GO-1] API 🚀: Validate MX Record Setup for Inbound Parse Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Class | Method                                                                  
 *IntegrationsApi* | [**Delete**](https://docs.novu.co/platform/integrations)                         | **Delete** /integrations/:integrationId | Delete an integration
 *IntegrationsApi* | [**Get**](https://docs.novu.co/platform/integrations)                            | **Get** /integrations                   | Get all integrations
 *IntegrationsApi* | [**GetActive**](https://docs.novu.co/platform/intergations)                      | **Get** /integrations/active            | Get all active integrations
+*InboundParserApi* | [**Get**](https://docs.novu.co/platform/inbound-parse-webhook/)                      | **Get** /inbound-parse/mx/status            | Validate the mx record setup for the inbound parse functionality 
 
 ## Authorization (api-key)
 

--- a/lib/inbound_parser.go
+++ b/lib/inbound_parser.go
@@ -1,0 +1,30 @@
+package lib
+
+import (
+	"context"
+	"net/http"
+)
+
+type IInboundParser interface {
+	Get(ctx context.Context) (*InboundParserResponse, error)
+}
+
+type InboundParserService service
+
+func (i *InboundParserService) Get(ctx context.Context) (*InboundParserResponse, error) {
+	var resp InboundParserResponse
+
+	URL := i.client.config.BackendURL.JoinPath("inbound-parse", "mx", "status")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = i.client.sendRequest(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/lib/inbound_parser_test.go
+++ b/lib/inbound_parser_test.go
@@ -1,0 +1,49 @@
+package lib_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboundParserService_Get_Success(t *testing.T) {
+	var expectedResponse lib.MxRecordConfiguredStatus
+
+	inboundParserService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Write the expected response as JSON
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(expectedResponse)
+		assert.NoError(t, err)
+
+		t.Run("Header must contain ApiKey", func(t *testing.T) {
+			authKey := r.Header.Get("Authorization")
+			assert.True(t, strings.Contains(authKey, novuApiKey))
+			assert.True(t, strings.HasPrefix(authKey, "ApiKey"))
+		})
+
+		t.Run("URL and request method is as expected", func(t *testing.T) {
+			expectedURL := "/inbound-parse/mx/status"
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, expectedURL, r.RequestURI)
+		})
+
+	}))
+
+	defer inboundParserService.Close()
+
+	ctx := context.Background()
+	i := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(inboundParserService.URL)})
+
+	_, err := i.InboundParser.Get(ctx)
+
+	require.Nil(t, err)
+}

--- a/lib/model.go
+++ b/lib/model.go
@@ -325,3 +325,10 @@ type BroadcastEventToAll struct {
 	TransactionId string      `json:"transactionId,omitempty"`
 	Actor         interface{} `json:"actor,omitempty"`
 }
+
+type MxRecordConfiguredStatus struct {
+	MxRecordConfigured bool `json:"mxRecordConfigured"`
+}
+type InboundParserResponse struct {
+	Data MxRecordConfiguredStatus `json:"data"`
+}

--- a/lib/novu.go
+++ b/lib/novu.go
@@ -32,6 +32,7 @@ type APIClient struct {
 	EventApi        *EventService
 	TopicsApi       *TopicService
 	IntegrationsApi *IntegrationService
+	InboundParser   *InboundParserService
 }
 
 type service struct {


### PR DESCRIPTION
## What does this PR do?
- Adds Inbound Parser functionality for validating mx records
- Fixes issue #8 

## How should this be tested manually?
- Run the following:
```golang

package main

import (
	"context"
	"fmt"
	novu "github.com/novuhq/go-novu/lib"
	"log"
)

func main() {
	apiKey := "<REPLACE_WITH_YOUR_API_KEY>"
        ctx := context.Background()
        
        novuClient := novu.NewAPIClient(apiKey, &novu.Config{})
        resp, err := novuClient.InboundParser.Get(ctx)
        if err != nil {
		log.Fatal("novu error", err.Error())
		return
	}

	fmt.Println(resp.Data.MxRecordConfigured)
	
	}
```

Any Background Context?
- N/A