### PR TITLE
feat: add payload option to GET subscriber feed api

### DIFF
--- a/lib/model.go
+++ b/lib/model.go
@@ -165,9 +165,13 @@ type SubscribersTopicRequest struct {
 }
 
 type SubscriberNotificationFeedOptions struct {
-	Page           int    `queryKey:"page"`
-	FeedIdentifier string `queryKey:"feedIdentifier"`
-	Seen           bool   `queryKey:"seen"`
+	Page           int         `queryKey:"page"`
+	FeedIdentifier string      `queryKey:"feedIdentifier"`
+	Seen           bool        `queryKey:"seen"`
+	Payload        interface{} `queryKey:"payload"`
+}
+type Base64Payload struct {
+	Payload string `queryKey:"payload"`
 }
 
 type SubscriberUnseenCountOptions struct {
@@ -235,7 +239,7 @@ type CTA struct {
 	Type   string `json:"type"`
 	Action struct {
 		Status  string `json:"status"`
-		Buttons struct {
+		Buttons []struct {
 			Type          string `json:"type"`
 			Content       string `json:"content"`
 			ResultContent string `json:"resultContent"`

--- a/lib/subscribers.go
+++ b/lib/subscribers.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -108,6 +109,23 @@ func (s *SubscriberService) GetNotificationFeed(ctx context.Context, subscriberI
 
 	if opts != nil {
 		queryValues := URL.Query()
+		if opts.Payload != nil {
+			var payloadOpts Base64Payload
+			payloadString, err := json.Marshal(opts.Payload)
+			if err != nil {
+				return nil, err
+			}
+			opts.Payload = nil
+
+			payloadOpts.Payload = base64.StdEncoding.EncodeToString(payloadString)
+			params, err := GenerateQueryParamsFromStruct(payloadOpts)
+			if err != nil {
+				return nil, err
+			}
+			for _, param := range params {
+				queryValues.Add(param.Key, param.Value)
+			}
+		}
 
 		params, err := GenerateQueryParamsFromStruct(*opts)
 		if err != nil {

--- a/lib/subscribers_test.go
+++ b/lib/subscribers_test.go
@@ -177,15 +177,19 @@ func TestSubscriberService_GetNotificationFeed_Success(t *testing.T) {
 	page := 1
 	seen := true
 	feedIdentifier := "feed_identifier"
+	payload := map[string]interface{}{
+		"name": "test",
+	}
 
 	opts := lib.SubscriberNotificationFeedOptions{
 		Page:           page,
 		Seen:           seen,
 		FeedIdentifier: feedIdentifier,
+		Payload:        payload,
 	}
 
 	httpServer := createTestServer(t, TestServerOptions[io.Reader, *lib.SubscriberNotificationFeedResponse]{
-		expectedURLPath:    fmt.Sprintf("/v1/subscribers/%s/notifications/feed?feedIdentifier=%s&page=%s&seen=%s", subscriberID, feedIdentifier, strconv.Itoa(page), strconv.FormatBool(seen)),
+		expectedURLPath:    fmt.Sprintf("/v1/subscribers/%s/notifications/feed?feedIdentifier=%s&page=%s&payload=eyJuYW1lIjoidGVzdCJ9&seen=%s", subscriberID, feedIdentifier, strconv.Itoa(page), strconv.FormatBool(seen)),
 		expectedSentMethod: http.MethodGet,
 		expectedSentBody:   http.NoBody,
 		responseStatusCode: http.StatusOK,


### PR DESCRIPTION
closes #23 

## changes
- SubscriberNotificationFeedOptions struct to support payload query
- GetNotificationFeed to convert the payload to base64 and send
- noticed wrong type for `CTA.Action.Buttons`, changed type to Array