### PR TITLE
feat: add subscriber credential update sdk method

### DIFF
--- a/lib/model.go
+++ b/lib/model.go
@@ -7,6 +7,7 @@ import (
 
 type ChannelType string
 type GeneralError error
+type ProviderIdType string
 
 const Version = "v1"
 
@@ -21,6 +22,18 @@ const (
 	EMAIL  ChannelType = "EMAIL"
 	SMS    ChannelType = "SMS"
 	DIRECT ChannelType = "DIRECT"
+)
+
+const (
+	slack       ProviderIdType = "slack"
+	discord     ProviderIdType = "discord"
+	msteams     ProviderIdType = "msteams"
+	mattermost  ProviderIdType = "mattermost"
+	fcm         ProviderIdType = "fcm"
+	apns        ProviderIdType = "apns"
+	expo        ProviderIdType = "expo"
+	oneSignal   ProviderIdType = "one-signal"
+	pushWebhook ProviderIdType = "push-webhook"
 )
 
 type Data struct {
@@ -229,6 +242,18 @@ type SubscriberUnseenCountResponse struct {
 	Data struct {
 		Count int `json:"count"`
 	} `json:"data"`
+}
+
+type Credentials struct {
+	WebhookUrl   string   `json:"webhookUrl,omitempty"`
+	Channel      string   `json:"channel,omitempty"`
+	DeviceTokens []string `json:"deviceTokens,omitempty"`
+}
+
+type SubscriberCredentialPayload struct {
+	Credentials           Credentials    `json:"credentials"`
+	IntegrationIdentifier string         `json:"integrationIdentifier,omitempty"`
+	ProviderId            ProviderIdType `json:"providerId"`
 }
 
 type CTA struct {

--- a/lib/subscribers.go
+++ b/lib/subscribers.go
@@ -15,6 +15,7 @@ type ISubscribers interface {
 	Identify(ctx context.Context, subscriberID string, data interface{}) (SubscriberResponse, error)
 	Get(ctx context.Context, subscriberID string) (SubscriberResponse, error)
 	Update(ctx context.Context, subscriberID string, data interface{}) (SubscriberResponse, error)
+	UpdateCredentials(ctx context.Context, subscriberID string, payload SubscriberCredentialPayload) (SubscriberResponse, error)
 	Delete(ctx context.Context, subscriberID string) (SubscriberResponse, error)
 	GetNotificationFeed(ctx context.Context, subscriberID string, opts *SubscriberNotificationFeedOptions) (*SubscriberNotificationFeedResponse, error)
 	GetUnseenCount(ctx context.Context, subscriberID string, opts *SubscriberUnseenCountOptions) (*SubscriberUnseenCountResponse, error)
@@ -69,6 +70,25 @@ func (s *SubscriberService) Get(ctx context.Context, subscriberID string) (Subsc
 func (s *SubscriberService) Update(ctx context.Context, subscriberID string, data interface{}) (SubscriberResponse, error) {
 	var resp SubscriberResponse
 	URL := s.client.config.BackendURL.JoinPath("subscribers", subscriberID)
+
+	jsonBody, _ := json.Marshal(data)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, URL.String(), bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return resp, err
+	}
+
+	_, err = s.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+func (s *SubscriberService) UpdateCredentials(ctx context.Context, subscriberID string, data SubscriberCredentialPayload) (SubscriberResponse, error) {
+	var resp SubscriberResponse
+	URL := s.client.config.BackendURL.JoinPath("subscribers", subscriberID, "credentials")
 
 	jsonBody, _ := json.Marshal(data)
 

--- a/lib/subscribers_test.go
+++ b/lib/subscribers_test.go
@@ -132,6 +132,61 @@ func TestSubscriberService_Update_Success(t *testing.T) {
 	})
 }
 
+func TestSubscriberService_Update_Credentials_Success(t *testing.T) {
+	var (
+		updateSubscriberCreds lib.SubscriberCredentialPayload
+		receivedBody          lib.SubscriberCredentialPayload
+		expectedRequest       lib.SubscriberCredentialPayload
+		expectedResponse      lib.SubscriberResponse
+	)
+
+	subscriberService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if err := json.NewDecoder(req.Body).Decode(&receivedBody); err != nil {
+			log.Printf("error in unmarshalling %+v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		t.Run("Header must contain ApiKey", func(t *testing.T) {
+			authKey := req.Header.Get("Authorization")
+			assert.True(t, strings.Contains(authKey, novuApiKey))
+			assert.True(t, strings.HasPrefix(authKey, "ApiKey"))
+		})
+
+		t.Run("URL and request method is as expected", func(t *testing.T) {
+			expectedURL := "/v1/subscribers/" + subscriberID + "/credentials"
+			assert.Equal(t, http.MethodPut, req.Method)
+			assert.Equal(t, expectedURL, req.RequestURI)
+		})
+
+		t.Run("Request is as expected", func(t *testing.T) {
+			fileToStruct(filepath.Join("../testdata", "update_subscriber_credentials.json"), &expectedRequest)
+			assert.Equal(t, expectedRequest, receivedBody)
+		})
+
+		var resp lib.SubscriberResponse
+		fileToStruct(filepath.Join("../testdata", "subscriber_response.json"), &resp)
+
+		w.WriteHeader(http.StatusOK)
+		bb, _ := json.Marshal(resp)
+		w.Write(bb)
+	}))
+
+	ctx := context.Background()
+	fileToStruct(filepath.Join("../testdata", "update_subscriber_credentials.json"), &updateSubscriberCreds)
+
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(subscriberService.URL)})
+
+	resp, err := c.SubscriberApi.UpdateCredentials(ctx, subscriberID, updateSubscriberCreds)
+	require.Nil(t, err)
+	assert.NotNil(t, resp)
+
+	t.Run("Response is as expected", func(t *testing.T) {
+		fileToStruct(filepath.Join("../testdata", "subscriber_response.json"), &expectedResponse)
+		assert.Equal(t, expectedResponse, resp)
+	})
+}
+
 func TestSubscriberService_Delete_Success(t *testing.T) {
 	var expectedResponse lib.SubscriberResponse
 

--- a/testdata/update_subscriber_credentials.json
+++ b/testdata/update_subscriber_credentials.json
@@ -1,0 +1,11 @@
+{
+  "credentials": {
+    "webhookUrl": "webhook",
+    "channel": "channel",
+    "deviceTokens": [
+      "token1"
+    ]
+  },
+  "providerId": "slack",
+  "integrationIdentifier": "123"
+}


### PR DESCRIPTION
closes #32
### changes
- Add new method to update subscriber credentials
- add relevant test cases