### PR TITLE
feat-add feeds api

### DIFF
--- a/lib/feeds.go
+++ b/lib/feeds.go
@@ -1,0 +1,55 @@
+package lib
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type FeedsService service
+
+func (e *FeedsService) CreateFeed(ctx context.Context, name string) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("feeds")
+	n := map[string]string{"name": name}
+	jsonBody, _ := json.Marshal(n)
+	b := bytes.NewBuffer(jsonBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, URL.String(), b)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (e *FeedsService) GetFeeds(ctx context.Context) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("feeds")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), http.NoBody)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (e *FeedsService) DeleteFeed(ctx context.Context, feedId string) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("feeds", feedId)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, URL.String(), http.NoBody)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}

--- a/lib/feeds_test.go
+++ b/lib/feeds_test.go
@@ -1,0 +1,87 @@
+package lib_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+)
+
+var feedsApiResponse = `{
+    "data": {
+        "_id": "string",
+        "name": "string",
+        "identifier": "string",
+        "_environmentId": "string",
+        "_organizationId": "string"
+    }
+}
+`
+
+func TestCreateFeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Want POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feeds" {
+			t.Errorf("Want /v1/feeds, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(feedsApiResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+	resp, err := c.FeedsApi.CreateFeed(context.Background(), "FeedyMcFeederson")
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}
+
+func TestGetFeeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Want GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feeds" {
+			t.Errorf("Want /v1/feeds, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(feedsApiResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+	resp, err := c.FeedsApi.GetFeeds(context.Background())
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}
+
+func TestDeleteFeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Want DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/feeds/FeedId" {
+			t.Errorf("Want /v1/feeds/FeedId, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(feedsApiResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+	resp, err := c.FeedsApi.DeleteFeed(context.Background(), "FeedId")
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}

--- a/lib/novu.go
+++ b/lib/novu.go
@@ -32,6 +32,7 @@ type APIClient struct {
 	EventApi         *EventService
 	ExecutionsApi    *ExecutionsService
 	MessagesApi      *MessagesService
+	FeedsApi         *FeedsService
 	TopicsApi        *TopicService
 	IntegrationsApi  *IntegrationService
 	InboundParserApi *InboundParserService
@@ -55,6 +56,7 @@ func NewAPIClient(apiKey string, cfg *Config) *APIClient {
 	// API Services
 	c.EventApi = (*EventService)(&c.common)
 	c.ExecutionsApi = (*ExecutionsService)(&c.common)
+	c.FeedsApi = (*FeedsService)(&c.common)
 	c.SubscriberApi = (*SubscriberService)(&c.common)
 	c.MessagesApi = (*MessagesService)(&c.common)
 	c.TopicsApi = (*TopicService)(&c.common)


### PR DESCRIPTION
Issue: https://github.com/novuhq/go-novu/issues/49

Adds the feeds api methods per [https://api.novu.co/api#/Feeds/FeedsController_createFeed](https://api.novu.co/api#/Feeds/FeedsController_createFeed)

Adds unit tests for new methods

I did not not create an interface for the feeds service as I didn't see the other ones, such as on events.go actually being used anywhere, and I didn't see the need for creating one since the interface doesn't need to be passed anywhere as well. I think leaving it out could help with setting a pattern for future contributors for not writing code that is not implemented.

I did the same thing with the JsonResponse type in models.go. So that it doesn't continue to a pattern of multiple structs that are all the same thing.

i embedded the JsonResponse into the Subscriber and Events response types - so they are the same. I did this instead of deleting them to account for backwards compatibility in case there is anyone using this as a package and upgrade  -this way their code doesn't break.  For this same reason I didn't delete the unused interfaces in other files.

