### PR TITLE
feat-add messages api

### DIFF
--- a/lib/messages.go
+++ b/lib/messages.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type MessagesService service
+
+func (e *MessagesService) GetMessages(ctx context.Context, q QueryBuilder) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("messages")
+	URL.RawQuery = q.BuildQuery()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), http.NoBody)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (e *MessagesService) DeleteMessage(ctx context.Context, messageId string) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("messages", messageId)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, URL.String(), http.NoBody)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (q MessagesQueryParams) BuildQuery() string {
+	params := url.Values{}
+	if q.Channel != "" {
+		params.Add("channel", q.Channel)
+	}
+	if q.SubscriberId != "" {
+		params.Add("subscriberId", q.SubscriberId)
+	}
+	if q.TransactionId != nil && len(q.TransactionId) > 0 {
+		for _, s := range q.TransactionId {
+			params.Add("transactionId", s)
+		}
+	}
+	if q.Page != 0 {
+		i := strconv.Itoa(q.Page)
+		params.Add("page", i)
+	}
+	if q.Limit != 0 {
+		i := strconv.Itoa(q.Limit)
+		params.Add("limit", i)
+	}
+	return params.Encode()
+}

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -1,0 +1,185 @@
+package lib_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+)
+
+var messagesGetResponse = `{
+	"hasMore": true,
+	"data": [
+	  {
+		"_id": "string",
+		"_environmentId": "string",
+		"_organizationId": "string",
+		"transactionId": "string",
+		"createdAt": "string",
+		"channels": "in_app",
+		"subscriber": {
+		  "firstName": "string",
+		  "_id": "string",
+		  "lastName": "string",
+		  "email": "string",
+		  "phone": "string"
+		},
+		"template": {
+		  "_id": "string",
+		  "name": "string",
+		  "triggers": [
+			{
+			  "type": "string",
+			  "identifier": "string",
+			  "variables": [
+				{
+				  "name": "string"
+				}
+			  ],
+			  "subscriberVariables": [
+				{
+				  "name": "string"
+				}
+			  ]
+			}
+		  ]
+		},
+		"jobs": [
+		  {
+			"_id": "string",
+			"type": "string",
+			"digest": {},
+			"executionDetails": [
+			  {
+				"_id": "string",
+				"_jobId": "string",
+				"status": "Success",
+				"detail": "string",
+				"isRetry": true,
+				"isTest": true,
+				"providerId": {},
+				"raw": "string",
+				"source": "Credentials"
+			  }
+			],
+			"step": {
+			  "_id": "string",
+			  "active": true,
+			  "filters": {
+				"isNegated": true,
+				"type": "BOOLEAN",
+				"value": "AND",
+				"children": [
+				  {
+					"field": "string",
+					"value": "string",
+					"operator": "LARGER",
+					"on": "subscriber"
+				  }
+				]
+			  },
+			  "template": {}
+			},
+			"payload": {},
+			"providerId": {},
+			"status": "string"
+		  }
+		]
+	  }
+	],
+	"pageSize": 0,
+	"page": 0
+  }
+`
+
+var messagesDeleteResponse = `{
+	"data": {
+	  "acknowledged": true,
+	  "status": "deleted"
+	}
+  }`
+
+func TestGetMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Want GET, got %s", r.Method)
+		}
+		expected := "/v1/messages?channel=email&transactionId=12&transactionId=156"
+		if r.URL.String() != expected {
+			t.Errorf("Want %s, got %s", expected, r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(messagesGetResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+
+	q := lib.MessagesQueryParams{TransactionId: []string{"12", "156"}, Channel: "email"}
+	resp, err := c.MessagesApi.GetMessages(context.Background(), q)
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}
+
+func TestMessagesBuildQuery(t *testing.T) {
+	tests := map[string]struct {
+		q    lib.MessagesQueryParams
+		want string
+	}{
+		"none": {
+			q:    lib.MessagesQueryParams{},
+			want: "",
+		},
+		"transactionIds only": {
+			q:    lib.MessagesQueryParams{TransactionId: []string{"1", "2", "2938a0AAcx42"}},
+			want: "transactionId=1&transactionId=2&transactionId=2938a0AAcx42",
+		},
+		"channel only": {
+			q:    lib.MessagesQueryParams{Channel: "email"},
+			want: "channel=email",
+		},
+		"all params": {
+			q: lib.MessagesQueryParams{
+				SubscriberId:  "subId",
+				Channel:       "email",
+				TransactionId: []string{"1", "2", "2938a0AAcx42"},
+				Page:          2,
+				Limit:         25,
+			},
+			want: "channel=email&limit=25&page=2&subscriberId=subId&transactionId=1&transactionId=2&transactionId=2938a0AAcx42",
+		},
+	}
+	for name, tc := range tests {
+		got := tc.q.BuildQuery()
+		if got != tc.want {
+			t.Errorf("%s-- want: %v, got: %v", name, tc.want, got)
+		}
+	}
+}
+
+func TestDeleteMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Want DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/messages/MessageId" {
+			t.Errorf("Want /v1/messages/MessageId, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(messagesDeleteResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+	resp, err := c.MessagesApi.DeleteMessage(context.Background(), "MessageId")
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}

--- a/lib/model.go
+++ b/lib/model.go
@@ -102,11 +102,6 @@ type ExecutionsQueryParams struct {
 	SubscriberId   string
 }
 
-// QueryBuilder gives us an interface to pass as arg to our API methods.
-// See messages.go for an example of implementing this interface
-type QueryBuilder interface {
-	BuildQuery() string
-}
 type EventResponse struct {
 	JsonResponse
 }
@@ -118,6 +113,20 @@ type EventRequest struct {
 	Overrides     interface{} `json:"overrides,omitempty"`
 	TransactionId string      `json:"transactionId,omitempty"`
 	Actor         interface{} `json:"actor,omitempty"`
+}
+
+type MessagesQueryParams struct {
+	Channel       string
+	SubscriberId  string
+	TransactionId []string
+	Page          int
+	Limit         int
+}
+
+// QueryBuilder gives us an interface to pass as arg to our API methods.
+// See messages.go for an example of implementing this interface
+type QueryBuilder interface {
+	BuildQuery() string
 }
 
 type SubscriberResponse struct {

--- a/lib/novu.go
+++ b/lib/novu.go
@@ -31,6 +31,7 @@ type APIClient struct {
 	SubscriberApi    *SubscriberService
 	EventApi         *EventService
 	ExecutionsApi    *ExecutionsService
+	MessagesApi      *MessagesService
 	TopicsApi        *TopicService
 	IntegrationsApi  *IntegrationService
 	InboundParserApi *InboundParserService
@@ -55,6 +56,7 @@ func NewAPIClient(apiKey string, cfg *Config) *APIClient {
 	c.EventApi = (*EventService)(&c.common)
 	c.ExecutionsApi = (*ExecutionsService)(&c.common)
 	c.SubscriberApi = (*SubscriberService)(&c.common)
+	c.MessagesApi = (*MessagesService)(&c.common)
 	c.TopicsApi = (*TopicService)(&c.common)
 	c.IntegrationsApi = (*IntegrationService)(&c.common)
 	c.InboundParserApi = (*InboundParserService)(&c.common)


### PR DESCRIPTION
Issue: https://github.com/novuhq/go-novu/issues/50

This adds the methods needed for the messages api per: [https://api.novu.co/api#/Messages/MessagesController_getMessages](https://api.novu.co/api#/Messages/MessagesController_getMessages)

It also introduces a `QueryBuilder` interface for passing parameters to build query strings with. Using this allows us to not need to rely on reflection which improves performancec and also gives us explicit types and handling for parsing query structs into strings