### PR TITLE
feat - add execution details api

### DIFF
--- a/lib/executions.go
+++ b/lib/executions.go
@@ -1,0 +1,35 @@
+package lib
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+type ExecutionsService service
+
+func (e *ExecutionsService) GetExecutions(ctx context.Context, q QueryBuilder) (JsonResponse, error) {
+	var resp JsonResponse
+	URL := e.client.config.BackendURL.JoinPath("execution-details")
+	URL.RawQuery = q.BuildQuery()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL.String(), http.NoBody)
+	if err != nil {
+		return resp, err
+	}
+	_, err = e.client.sendRequest(req, &resp)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (q ExecutionsQueryParams) BuildQuery() string {
+	params := url.Values{}
+	if q.NotificationId != "" {
+		params.Add("notificationId", q.NotificationId)
+	}
+	if q.SubscriberId != "" {
+		params.Add("subscriberId", q.SubscriberId)
+	}
+	return params.Encode()
+}

--- a/lib/executions_test.go
+++ b/lib/executions_test.go
@@ -1,0 +1,60 @@
+package lib_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/novuhq/go-novu/lib"
+)
+
+var executionsGetResponse = `{
+	"data": [
+	  {
+		"_id": "string",
+		"_organizationId": "string",
+		"_jobId": "string",
+		"_environmentId": "string",
+		"_notificationId": "string",
+		"_notificationTemplateId": "string",
+		"_subscriberId": "string",
+		"_messageId": "string",
+		"providerId": "string",
+		"transactionId": "string",
+		"channel": "in_app",
+		"detail": "string",
+		"source": "Credentials",
+		"status": "Success",
+		"isTest": true,
+		"isRetry": true,
+		"createdAt": "string"
+	  }
+	]
+  }
+`
+
+func TestGetExecutions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Want GET, got %s", r.Method)
+		}
+		expected := "/v1/execution-details?notificationId=12345&subscriberId=XYZ"
+		if r.URL.String() != expected {
+			t.Errorf("Want %s, got %s", expected, r.URL.String())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(executionsGetResponse))
+	}))
+	defer server.Close()
+	c := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(server.URL)})
+
+	q := lib.ExecutionsQueryParams{NotificationId: "12345", SubscriberId: "XYZ"}
+	resp, err := c.ExecutionsApi.GetExecutions(context.Background(), q)
+	if err != nil {
+		t.Errorf("Error should be nil, got %v", err)
+	}
+	if resp.Data == nil || resp.Data == "" {
+		t.Error("Expected response, got none")
+	}
+}

--- a/lib/model.go
+++ b/lib/model.go
@@ -94,9 +94,21 @@ type IAttachmentOptions struct {
 	Name     string        `json:"name,omitempty"`
 	Channels []ChannelType `json:"channels,omitempty"`
 }
-
-type EventResponse struct {
+type JsonResponse struct {
 	Data interface{} `json:"data"`
+}
+type ExecutionsQueryParams struct {
+	NotificationId string
+	SubscriberId   string
+}
+
+// QueryBuilder gives us an interface to pass as arg to our API methods.
+// See messages.go for an example of implementing this interface
+type QueryBuilder interface {
+	BuildQuery() string
+}
+type EventResponse struct {
+	JsonResponse
 }
 
 type EventRequest struct {
@@ -109,7 +121,7 @@ type EventRequest struct {
 }
 
 type SubscriberResponse struct {
-	Data interface{} `json:"data"`
+	JsonResponse
 }
 
 type SubscriberBulkCreateResponse struct {

--- a/lib/novu.go
+++ b/lib/novu.go
@@ -30,6 +30,7 @@ type APIClient struct {
 	// Api Service
 	SubscriberApi    *SubscriberService
 	EventApi         *EventService
+	ExecutionsApi    *ExecutionsService
 	TopicsApi        *TopicService
 	IntegrationsApi  *IntegrationService
 	InboundParserApi *InboundParserService
@@ -52,6 +53,7 @@ func NewAPIClient(apiKey string, cfg *Config) *APIClient {
 
 	// API Services
 	c.EventApi = (*EventService)(&c.common)
+	c.ExecutionsApi = (*ExecutionsService)(&c.common)
 	c.SubscriberApi = (*SubscriberService)(&c.common)
 	c.TopicsApi = (*TopicService)(&c.common)
 	c.IntegrationsApi = (*IntegrationService)(&c.common)


### PR DESCRIPTION
Issue: https://github.com/novuhq/go-novu/issues/48

Adds the methods for execution details per: [https://api.novu.co/api#/Execution%20Details/ExecutionDetailsController_getExecutionDetailsForNotification](https://api.novu.co/api#/Execution%20Details/ExecutionDetailsController_getExecutionDetailsForNotification)

Uses the `QueryBuilder` interface i added in the previous PR for Messages