### PR TITLE
Issue #42: Integration Method added

### DIFF
--- a/lib/integration.go
+++ b/lib/integration.go
@@ -14,6 +14,7 @@ type IIntegration interface {
 	GetWebhookSupportStatus(ctx context.Context, providerId string) (bool, error)
 	Update(ctx context.Context, integrationId string, request UpdateIntegrationRequest) (*IntegrationResponse, error)
 	Delete(ctx context.Context, integrationId string) (*IntegrationResponse, error)
+	SetPrimary(ctx context.Context, integrationId string) (*IntegrationResponse, error)
 }
 
 type IntegrationService service
@@ -142,6 +143,24 @@ func (i IntegrationService) Delete(ctx context.Context, integrationId string) (*
 
 	_, err = i.client.sendRequest(req, &response)
 
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (i IntegrationService) SetPrimary(ctx context.Context, integrationId string) (*IntegrationResponse, error) {
+	var response IntegrationResponse
+	URL := i.client.config.BackendURL.JoinPath("integrations", integrationId, "set-primary")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, URL.String(), http.NoBody)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = i.client.sendRequest(req, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -254,3 +254,30 @@ func TestDeleteActiveIntegration_Success(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestSetPrimaryIntegration_Success(t *testing.T) {
+	const integrationId = "integrationId"
+
+	var response *lib.IntegrationResponse
+	fileToStruct(filepath.Join("../testdata", "integration_response.json"), &response)
+
+	httpServer := IntegrationTestServer(t, IntegrationServerOptions[interface{}]{
+		ExpectedRequest: IntegrationRequestDetails[interface{}]{
+			Url:    fmt.Sprintf("/v1/integrations/%s/set-primary", integrationId),
+			Method: http.MethodPost,
+		},
+		ExpectedResponse: IntegrationResponseDetails{
+			StatusCode: http.StatusOK,
+			Body:       response,
+		},
+	})
+
+	ctx := context.Background()
+	novuClient := lib.NewAPIClient(novuApiKey, &lib.Config{BackendURL: lib.MustParseURL(httpServer.URL)})
+
+	res, err := novuClient.IntegrationsApi.SetPrimary(ctx, integrationId)
+
+	assert.Equal(t, response, res)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Resolves #42 

Added support for integration method `SetPrimary` that sets an integration as primary.
I was informed that `/v1/integrations/{channelType}/limit` and `/v1/integrations/in-app/status` APIs are not accessible externally.
So they've been skipped and the rest of the integration methods have already been implemented.