### PR TITLE
Removed Redundant Headings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ _InboundParserApi_ | [**Get**](https://docs.novu.co/platform/inbound-parse-webho
 
 ## Authorization (api-key)
 
-## Authorization (api-key)
-
 - **Type**: API key
 - **API key parameter name**: ApiKey
 - **Location**: HTTP header


### PR DESCRIPTION
The heading  "Authorization (api-key)" is included twice which is of no need. Removed one of the heading