### PR TITLE
feat: add support for auto semantic release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,30 @@
+name: Create Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+
+      - name: Install dependencies
+        run: npm install --no-save
+
+      - name: Release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release -e ./default-release-config.json -b master

--- a/default-release-config.json
+++ b/default-release-config.json
@@ -1,0 +1,36 @@
+module.exports = {
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {},
+        "releaseRules": [
+          {
+            "type": "refactor",
+            "release": "patch"
+          }
+        ]
+      }
+    ],
+    "@semantic-release/github",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "writerOpts": {
+          "commitsSort": [
+            "type",
+            "scope"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "echo new-release-version=${ nextRelease.version } >> $GITHUB_OUTPUT"
+      }
+    ]
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "go-novu",
+  "version": "0.0.1",
+  "dependencies": {
+    "semantic-release": "^19.0.2",
+    "@semantic-release/exec": "^6.0.3",
+    "conventional-changelog-conventionalcommits": "^4.6.3"
+  }
+}


### PR DESCRIPTION
This PR adds support to create new semantic release versions when new changes are merged into the master branch. 

This enforces standard commits messages to create new releases.

See here:

https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js