### PR TITLE
Fixed SubscriberApi.MarkMessageSeen

### DIFF
--- a/lib/model.go
+++ b/lib/model.go
@@ -239,10 +239,14 @@ type SubscriberUnseenCountOptions struct {
 	Seen *bool `json:"seen"`
 }
 
+type SubscriberMarkMessageSeenMark struct {
+	Seen bool `json:"seen"`
+	Read bool `json:"read"`
+}
+
 type SubscriberMarkMessageSeenOptions struct {
-	MessageID string `json:"messageId"`
-	Seen      bool   `json:"seen"`
-	Read      bool   `json:"read"`
+	MessageID string                        `json:"messageId"`
+	Mark      SubscriberMarkMessageSeenMark `json:"mark"`
 }
 
 type NotificationFeedData struct {
@@ -546,9 +550,8 @@ type ChangesApplyResponse struct {
 	Data []ChangesGetResponseData `json:"data,omitempty"`
 }
 
-
 type UpdateTenantRequest struct {
-	Name 	 string `json:"name"`
-	Data 	 map[string]interface{} `json:"data"`
-	Identifier string `json:"identifier"`
+	Name       string                 `json:"name"`
+	Data       map[string]interface{} `json:"data"`
+	Identifier string                 `json:"identifier"`
 }

--- a/lib/subscribers_test.go
+++ b/lib/subscribers_test.go
@@ -388,8 +388,10 @@ func TestSubscriberService_MarkMessageSeen(t *testing.T) {
 
 	opts := lib.SubscriberMarkMessageSeenOptions{
 		MessageID: "message_id",
-		Seen:      true,
-		Read:      true,
+		Mark: lib.SubscriberMarkMessageSeenMark{
+			Seen: true,
+			Read: true,
+		},
 	}
 
 	httpServer := createTestServer(t, TestServerOptions[lib.SubscriberMarkMessageSeenOptions, *lib.SubscriberNotificationFeedResponse]{


### PR DESCRIPTION
According to [API Reference](https://docs.novu.co/api-reference/subscribers/mark-a-subscriber-feed-message-as-seen) for `MarkMessageSeen` method, `seen` and `read` fields should be inside `mark` object

This PR changes `SubscriberMarkMessageSeenOptions` struct to valid request body format

Fixes #88 