### PR TITLE
Fixed SubscriberApi.UpdatePreferences

### DIFF
--- a/lib/model.go
+++ b/lib/model.go
@@ -19,9 +19,11 @@ const (
 )
 
 const (
-	EMAIL  ChannelType = "EMAIL"
-	SMS    ChannelType = "SMS"
-	DIRECT ChannelType = "DIRECT"
+	INAPP ChannelType = "in_app"
+	EMAIL ChannelType = "email"
+	SMS   ChannelType = "sms"
+	CHAT  ChannelType = "chat"
+	PUSH  ChannelType = "push"
 )
 
 const (
@@ -157,15 +159,22 @@ type Preference struct {
 }
 
 type Channel struct {
-	Email bool `json:"email"`
-	Sms   bool `json:"sms"`
-	Chat  bool `json:"chat"`
-	InApp bool `json:"in_app"`
-	Push  bool `json:"push"`
+	Email *bool `json:"email,omitempty"`
+	Sms   *bool `json:"sms,omitempty"`
+	Chat  *bool `json:"chat,omitempty"`
+	InApp *bool `json:"in_app,omitempty"`
+	Push  *bool `json:"push,omitempty"`
 }
 
 type SubscriberPreferencesResponse struct {
 	Data []struct {
+		Template   Template   `json:"template"`
+		Preference Preference `json:"preference"`
+	} `json:"data"`
+}
+
+type UpdateSubscriberPreferencesResponse struct {
+	Data struct {
 		Template   Template   `json:"template"`
 		Preference Preference `json:"preference"`
 	} `json:"data"`
@@ -177,8 +186,8 @@ type UpdateSubscriberPreferencesChannel struct {
 }
 
 type UpdateSubscriberPreferencesOptions struct {
-	Channel []UpdateSubscriberPreferencesChannel `json:"channel,omitempty"`
-	Enabled bool                                 `json:"enabled,omitempty"`
+	Channel *UpdateSubscriberPreferencesChannel `json:"channel,omitempty"`
+	Enabled *bool                               `json:"enabled,omitempty"`
 }
 
 type ListTopicsResponse struct {

--- a/lib/subscribers.go
+++ b/lib/subscribers.go
@@ -23,7 +23,7 @@ type ISubscribers interface {
 	GetUnseenCount(ctx context.Context, subscriberID string, opts *SubscriberUnseenCountOptions) (*SubscriberUnseenCountResponse, error)
 	MarkMessageSeen(ctx context.Context, subscriberID string, opts SubscriberMarkMessageSeenOptions) (*SubscriberNotificationFeedResponse, error)
 	GetPreferences(ctx context.Context, subscriberID string) (*SubscriberPreferencesResponse, error)
-	UpdatePreferences(ctx context.Context, subscriberID string, templateId string, opts *UpdateSubscriberPreferencesOptions) (*SubscriberPreferencesResponse, error)
+	UpdatePreferences(ctx context.Context, subscriberID string, templateId string, opts *UpdateSubscriberPreferencesOptions) (*UpdateSubscriberPreferencesResponse, error)
 }
 
 type SubscriberService service
@@ -234,8 +234,8 @@ func (s *SubscriberService) GetUnseenCount(ctx context.Context, subscriberID str
 	return &resp, nil
 }
 
-func (s *SubscriberService) UpdatePreferences(ctx context.Context, subscriberID string, templateId string, opts *UpdateSubscriberPreferencesOptions) (*SubscriberPreferencesResponse, error) {
-	var resp SubscriberPreferencesResponse
+func (s *SubscriberService) UpdatePreferences(ctx context.Context, subscriberID string, templateId string, opts *UpdateSubscriberPreferencesOptions) (*UpdateSubscriberPreferencesResponse, error) {
+	var resp UpdateSubscriberPreferencesResponse
 	URL := s.client.config.BackendURL.JoinPath("subscribers", subscriberID, "preferences", templateId)
 
 	var reqBody io.Reader = http.NoBody

--- a/lib/subscribers_test.go
+++ b/lib/subscribers_test.go
@@ -413,13 +413,12 @@ func TestSubscriberService_UpdatePreferences_Success(t *testing.T) {
 	var expectedResponse *lib.SubscriberPreferencesResponse
 	fileToStruct(filepath.Join("../testdata", "subscriber_preferences_response.json"), &expectedResponse)
 
+	enabled := true
 	var opts *lib.UpdateSubscriberPreferencesOptions = &lib.UpdateSubscriberPreferencesOptions{
-		Enabled: true,
-		Channel: []lib.UpdateSubscriberPreferencesChannel{
-			{
-				Type:    "email",
-				Enabled: true,
-			},
+		Enabled: &enabled,
+		Channel: &lib.UpdateSubscriberPreferencesChannel{
+			Type:    "email",
+			Enabled: true,
 		},
 	}
 	httpServer := createTestServer(t, TestServerOptions[*lib.UpdateSubscriberPreferencesOptions, *lib.SubscriberPreferencesResponse]{


### PR DESCRIPTION
This PR changes `UpdateSubscriberPreferencesOptions` struct to valid request body format
Field types in that struct changed to pointers, to avoid bug with `omitempty` tag, as described in issue #90

Added new struct `UpdateSubscriberPreferencesResponse`, because API endpoint returns single object in `data` field instead of array, which results in unmarshalling error

Added all notification channel types and made them optional, as API may return only some of them

Fixes #90